### PR TITLE
moved cob_supported_robots to separate repo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,6 @@ project(cob_supported_robots)
 find_package(catkin REQUIRED)
 
 set(robotlist
-    cob4-1
     cob4-2
     cob4-3
     cob4-4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(cob_supported_robots)
+
+find_package(catkin REQUIRED)
+
+set(robotlist
+    cob3-2
+    cob3-6
+    cob3-9
+    cob4-1
+    cob4-2
+    cob4-3
+    cob4-4
+    cob4-5
+    cob4-6
+    cob4-7
+    cob4-10
+    raw3-1
+    raw3-2
+    raw3-3
+    raw3-4
+    raw3-5
+    raw3-6
+)
+
+catkin_package(
+    CFG_EXTRAS cob_supported_robots-extras.cmake
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,9 +4,6 @@ project(cob_supported_robots)
 find_package(catkin REQUIRED)
 
 set(robotlist
-    cob3-2
-    cob3-6
-    cob3-9
     cob4-1
     cob4-2
     cob4-3
@@ -16,11 +13,8 @@ set(robotlist
     cob4-7
     cob4-10
     raw3-1
-    raw3-2
     raw3-3
-    raw3-4
     raw3-5
-    raw3-6
 )
 
 catkin_package(

--- a/cmake/cob_supported_robots-extras.cmake.in
+++ b/cmake/cob_supported_robots-extras.cmake.in
@@ -1,0 +1,1 @@
+set(@PROJECT_NAME@_ROBOTLIST @robotlist@)

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,15 @@
+<package format="2">
+  <name>cob_supported_robots</name>
+  <version>0.6.6</version>
+  <description>This package contains the list of supported robots within the care-o-bot family.</description>
+
+  <license>LGPL</license>
+
+  <url type="website">http://ros.org/wiki/cob_supported_robots</url>
+
+  <maintainer email="nhg@ipa.fhg.de">Nadia Hammoudeh Garcia</maintainer>
+  <author email="mathias.luedtke@ipa.fraunhofer.de">Mathias Lüdtke</author>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+</package>


### PR DESCRIPTION
@ipa-fmw @ipa-mdl 
because it requires less repos in the .rosinstall files than adding cob_robots (+all the overlays needed for cob_robots)

merge together with https://github.com/ipa320/cob_robots/pull/621