### PR TITLE
use license apache 2.0

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -3,7 +3,7 @@
   <version>0.6.6</version>
   <description>This package contains the list of supported robots within the care-o-bot family.</description>
 
-  <license>LGPL</license>
+  <license>Apache 2.0</license>
 
   <url type="website">http://ros.org/wiki/cob_supported_robots</url>
 


### PR DESCRIPTION
no external contributors

do not merge before: **August, 4th 2017**
merge together with other `use license apache 2.0` PRs